### PR TITLE
Assets download

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ resources:
 * `tag_prefix` this should match what releases are listed as for the repository naming standard you want to check, ie nginx uses `release-1.12.0`, so the prefix is `release-`
 * `per_page` specify the number of results to return in the github api call, defaults to 20 but you can increase if you are getting no results in a repo with lots of tags
 * `version_family` you can use this to drill down the versions you want to watch, ie if you only want nginx version `1.12` and its patch releases, you can use `version_family: 1.12`
+* `get_assets` set to True to only get tags that have release assets associated to them
+* `get_source_tar` to False to not download the source tarball
 
 ## Behavior
 

--- a/scripts/check
+++ b/scripts/check
@@ -95,6 +95,29 @@ for ((i=0; i <= $((${#versions_sorted[@]} - 2)); ++i)); do
   done
 done
 
+
+# Lets separate out any releases that have no assets, we only want ones with assets
+if [ ! -z "$get_assets" ]
+then
+  versions_sorted2=()
+  for ((i=0; i < $((${#versions_sorted[@]})); ++i))
+  do
+    github_api_releases2=$(curl --max-time 900 --connect-timeout 300 -s https://api.github.com/repos/${github_owner}/${github_repo}/releases/tags/${release_name}${versions_sorted[i]}?${api_token_header}per_page=${github_api_per_page})
+    release_assets=$(echo $github_api_releases2 | jq -r '.assets' | jq -r '.[].name')
+    if [ "$release_assets" ]
+    then
+      versions_sorted2+=(${versions_sorted[i]})
+    fi
+  done
+  if [ ${#versions_sorted2[@]} -ne 0 ]
+  then
+    versions_sorted=("${versions_sorted2[@]}")
+  else
+    echo "No releases with assets found"
+    exit 1
+  fi
+fi
+
 # Create the empty json string
 versions_json=''
 
@@ -103,8 +126,6 @@ keep_it=false
 # If we want the latest, spit it out
 if [ "$release_version" == "latest" ]
 then
-  github_api_releases2=$(curl --max-time 900 --connect-timeout 300 -s https://api.github.com/repos/${github_owner}/${github_repo}/releases/tags/${release_name}${versions_sorted[$((${#versions_sorted[@]}-1))]}?${api_token_header}per_page=${github_api_per_page})
-  release_assets=$(echo $github_api_releases2 | jq -r '.assets' | jq -r '.[].name')
   versions_json="${versions_json},{\"version\":\"${versions_sorted[$((${#versions_sorted[@]}-1))]}\"}"
 # Else loop through the list and display versions from requested version onwards
 else
@@ -116,12 +137,6 @@ else
     fi
     if [ "$keep_it" == "true" ]
     then
-			if [ ! -z "$get_assets" ]
-			then
-				github_api_releases2=$(curl --max-time 900 --connect-timeout 300 -s https://api.github.com/repos/${github_owner}/${github_repo}/releases/tags/${release_name}${versions_sorted[i]}?${api_token_header}per_page=${github_api_per_page})
-				release_assets=$(echo $github_api_releases2 | jq -r '.assets')
-				echo $release_assets | jq
-			fi
       versions_json="${versions_json},{\"version\":\"${versions_sorted[i]}\"}"
     fi
   done

--- a/scripts/check
+++ b/scripts/check
@@ -46,10 +46,17 @@ release_ignore=$( jq -r '.source.tag_ignore // ""' < ${payload})
 release_name=$( jq -r '.source.tag_prefix // ""' < ${payload})
 release_version_family=$( jq -r '.source.version_family // ""' < ${payload})
 release_version=$( jq -r '.version.version // "latest"' < ${payload})
+get_assets=$( jq -r '.source.get_assets // ""' < ${payload})
 
 # Define semver regex formats
 # we only want final releases, no dev/pre-release unless there is an easy way to compare 1.1.1RC1 to 1.1.1ALPHA2 and 1.1.1BETA3 and which one comes first
-semver_regex_escaped='[\\.]?([0-9]+\\.)?([0-9]+\\.)?([0-9]+)?$'
+if [ ! -z "$release_version_family" ]
+then
+  semver_regex_escaped='[\\.]?([0-9]+\\.)?([0-9]+\\.)?([0-9]+)?$'
+else
+  semver_regex_escaped='([0-9]+\\.)([0-9]+\\.)([0-9]+)$'
+fi
+
 
 release_ignore_test=""
 # Prepare the matching terms for jq
@@ -96,6 +103,8 @@ keep_it=false
 # If we want the latest, spit it out
 if [ "$release_version" == "latest" ]
 then
+  github_api_releases2=$(curl --max-time 900 --connect-timeout 300 -s https://api.github.com/repos/${github_owner}/${github_repo}/releases/tags/${release_name}${versions_sorted[$((${#versions_sorted[@]}-1))]}?${api_token_header}per_page=${github_api_per_page})
+  release_assets=$(echo $github_api_releases2 | jq -r '.assets' | jq -r '.[].name')
   versions_json="${versions_json},{\"version\":\"${versions_sorted[$((${#versions_sorted[@]}-1))]}\"}"
 # Else loop through the list and display versions from requested version onwards
 else
@@ -107,6 +116,12 @@ else
     fi
     if [ "$keep_it" == "true" ]
     then
+			if [ ! -z "$get_assets" ]
+			then
+				github_api_releases2=$(curl --max-time 900 --connect-timeout 300 -s https://api.github.com/repos/${github_owner}/${github_repo}/releases/tags/${release_name}${versions_sorted[i]}?${api_token_header}per_page=${github_api_per_page})
+				release_assets=$(echo $github_api_releases2 | jq -r '.assets')
+				echo $release_assets | jq
+			fi
       versions_json="${versions_json},{\"version\":\"${versions_sorted[i]}\"}"
     fi
   done

--- a/scripts/in
+++ b/scripts/in
@@ -39,6 +39,7 @@ release_name=$( jq -r '.source.tag_prefix // ""' < ${payload})
 release_version_family=$( jq -r '.source.version_family // ""' < ${payload})
 release_version=$( jq -r '.version.version // "latest"' < ${payload})
 get_assets=$( jq -r '.source.get_assets // ""' < ${payload})
+get_source_tar=$( jq -r '.source.get_source_tar // "True"' < ${payload})
 version="$(jq -r '.version // ""' < "${payload}")"
 
 release_file=$release_name$release_version
@@ -52,6 +53,7 @@ if [ $(validate_url $file_url) ]
 then
   echo "valid"
   mkdir -p "${destination}"
+  # if we want assets, lets download them
   if [ ! -z "$get_assets" ]
   then
     for row in $(echo "${release_assets}" | jq -r '.[] | @base64')
@@ -59,12 +61,19 @@ then
       _jq() {
        echo ${row} | base64 --decode | jq -r ${1}
       }
-      wget -O "${destination}/$(_jq '.name')" "$(_jq '.browser_download_url')"
+      if [ "$get_assets" ]
+      then
+        wget -O "${destination}/$(_jq '.name')" "$(_jq '.browser_download_url')"
+        echo "$(_jq '.browser_download_url')" > ${destination}/$(_jq '.name')_asset_url
+      fi
     done
   fi
-  wget -O "${destination}/source.tar.gz" "${file_url}"
+  if [ "$get_source_tar" == "True" ]
+  then
+    wget -O "${destination}/source.tar.gz" "${file_url}"
+    echo "${file_url}" > "${destination}/url"
+  fi
   echo "${release_version}" > "${destination}/version"
-  echo "${file_url}" > "${destination}/url"
 fi
 
 jq -n "{

--- a/scripts/in
+++ b/scripts/in
@@ -14,7 +14,7 @@ exec 1>&2 # redirect all output to stderr for logging
 #
 
 validate_url() {
-  if [[ $(wget -S --spider $1  2>&1 | grep 'HTTP/1.1 200 OK') ]]; then echo "true"; fi
+  if [[ $(wget -S --spider $1  2>&1 | egrep 'HTTP/1.1 200 OK|HTTP/1.1 302') ]]; then echo "true"; fi
 }
 
 tmpdir=${tmpdir:-/tmp}
@@ -38,14 +38,26 @@ github_api_per_page=$( jq -r '.source.per_page // "20"' < ${payload})
 release_name=$( jq -r '.source.tag_prefix // ""' < ${payload})
 release_version_family=$( jq -r '.source.version_family // ""' < ${payload})
 release_version=$( jq -r '.version.version // "latest"' < ${payload})
+file_override=$( jq -r '.source.file_override // ""' < ${payload})
 version="$(jq -r '.version // ""' < "${payload}")"
 
 release_file=$release_name$release_version
 file_url=https://github.com/${github_owner}/${github_repo}/archive/${release_file}.tar.gz
+if [ ! -z $file_override ]
+then
+  file_url=https://github.com/${github_owner}/${github_repo}/releases/download/${release_name}${release_version}/${file_override}
+fi
+#echo $file_url
 if [ $(validate_url $file_url) ]
 then
+  echo "valid"
   mkdir -p "${destination}"
-  wget -O "${destination}/source.tar.gz" "${file_url}"
+  if [ ! -z $file_override ]
+  then
+    wget -O "${destination}/${file_override}" "${file_url}"
+  else
+    wget -O "${destination}/source.tar.gz" "${file_url}"
+  fi
   echo "${release_version}" > "${destination}/version"
   echo "${file_url}" > "${destination}/url"
 fi

--- a/scripts/in
+++ b/scripts/in
@@ -14,7 +14,7 @@ exec 1>&2 # redirect all output to stderr for logging
 #
 
 validate_url() {
-  if [[ $(wget -S --spider $1  2>&1 | egrep 'HTTP/1.1 200 OK|HTTP/1.1 302') ]]; then echo "true"; fi
+  if [[ $(wget -S --spider $1  2>&1 | grep 'HTTP/1.1 200 OK') ]]; then echo "true"; fi
 }
 
 tmpdir=${tmpdir:-/tmp}
@@ -38,26 +38,31 @@ github_api_per_page=$( jq -r '.source.per_page // "20"' < ${payload})
 release_name=$( jq -r '.source.tag_prefix // ""' < ${payload})
 release_version_family=$( jq -r '.source.version_family // ""' < ${payload})
 release_version=$( jq -r '.version.version // "latest"' < ${payload})
-file_override=$( jq -r '.source.file_override // ""' < ${payload})
+get_assets=$( jq -r '.source.get_assets // ""' < ${payload})
 version="$(jq -r '.version // ""' < "${payload}")"
 
 release_file=$release_name$release_version
 file_url=https://github.com/${github_owner}/${github_repo}/archive/${release_file}.tar.gz
-if [ ! -z $file_override ]
-then
-  file_url=https://github.com/${github_owner}/${github_repo}/releases/download/${release_name}${release_version}/${file_override}
-fi
+
+github_api_releases=$(curl --max-time 900 --connect-timeout 300 -s https://api.github.com/repos/${github_owner}/${github_repo}/releases/tags/${release_name}${release_version}?${api_token_header}per_page=${github_api_per_page})
+release_assets=$(echo $github_api_releases | jq -r '.assets')
+
 #echo $file_url
 if [ $(validate_url $file_url) ]
 then
   echo "valid"
   mkdir -p "${destination}"
-  if [ ! -z $file_override ]
+  if [ ! -z "$get_assets" ]
   then
-    wget -O "${destination}/${file_override}" "${file_url}"
-  else
-    wget -O "${destination}/source.tar.gz" "${file_url}"
+    for row in $(echo "${release_assets}" | jq -r '.[] | @base64')
+    do
+      _jq() {
+       echo ${row} | base64 --decode | jq -r ${1}
+      }
+      wget -O "${destination}/$(_jq '.name')" "$(_jq '.browser_download_url')"
+    done
   fi
+  wget -O "${destination}/source.tar.gz" "${file_url}"
   echo "${release_version}" > "${destination}/version"
   echo "${file_url}" > "${destination}/url"
 fi


### PR DESCRIPTION
Some releases don't have assets, so using these changes we can specify an exact semver regex (to ignore -beta# or -RC) by default, and also to specify to get assets.
Checks against GH releases for assets, then only adds them into an array if they match semver.